### PR TITLE
Fix missing custom headers for searchapi endpoints

### DIFF
--- a/factories/searchApiSearcherFactory.js
+++ b/factories/searchApiSearcherFactory.js
@@ -78,8 +78,10 @@
       //baseUrl = queryTemplateSvc.hydrate(baseUrl, self.queryText, {encodeURI: true, defaultKw: '""'});
       self.inError  = false;
 
+      var headers = esUrlSvc.getHeaders(uri, self.config.customHeaders);
+
       activeQueries.count++;
-      return transport.query(url, payload, null)
+      return transport.query(url, payload, headers)
         .then(function success(httpConfig) {
           const data = httpConfig.data;
 


### PR DESCRIPTION
As seen in https://github.com/o19s/quepid/issues/890, when setting up an `apisearch` endpoint, no custom headers are ever sent by the browser.

In this PR I update the `searchapi` Searcher to get headers the same way the `es` Searcher does and pass them along to the transport.

In my reading, this was the only Searcher not propagating these headers. I re-used `esUrlSvc.getHeaders` as this service was already in use in the `searchapi` Searcher.
